### PR TITLE
Updated Python References

### DIFF
--- a/README.md
+++ b/README.md
@@ -97,7 +97,7 @@ Check their names [here](https://drive.google.com/file/d/15rjcHqjDN7gPU5e6nxb_9N
        * Refrences:    
          - [Tutorialspoint](https://www.tutorialspoint.com/python/index.htm)   
          - [w3schools](https://www.w3schools.com/python/)
-         - [Scaler Topics](https://www.w3schools.com/python/)
+         - [Scaler Topics](https://www.scaler.com/topics/python/)
        * Time Required: same as above
        * **Important Callout:** Some companies don't allow python as a choice in their online coding test, so prepare accordingly
 </details>


### PR DESCRIPTION
Wrong link was added on "Scaler Topics" Changed it to https://www.scaler.com/topics/python/